### PR TITLE
이미지 첨부한 게시물 관련 수정중

### DIFF
--- a/front/src/views/BoardDetail/index.tsx
+++ b/front/src/views/BoardDetail/index.tsx
@@ -100,7 +100,10 @@ const BoardDetail = () => {
       navigator(MAIN_PATH());
       return;
     }
-    getBoardRequest(boardId).then(getBoardResponse);
+    getBoardRequest(boardId).then((response) => {
+      console.log("Board Content:", response);
+      getBoardResponse(response);
+    });
   }, [boardId, loginUser]);
   const getBoardResponse = (
     responseBody: GetBoardDetailResponseDto | ResponseDto | null

--- a/front/src/views/BoardDetail/style.css
+++ b/front/src/views/BoardDetail/style.css
@@ -290,4 +290,5 @@
 .board-detail {
   white-space: pre-wrap; /* 공백과 줄바꿈을 유지하며 줄바꿈 */
   word-wrap: break-word; /* 긴 단어를 줄바꿈 */
+  height: 100px;
 }

--- a/front/src/views/BoardWrite/index.tsx
+++ b/front/src/views/BoardWrite/index.tsx
@@ -66,7 +66,6 @@ const BoardWrite = () => {
           (async () => {
             const formData = new FormData();
             formData.append("file", blob);
-            alert("69줄");
             const data = await axios.post(
               `${BACK_DOMAIN()}/file/save/temp/image`,
               formData

--- a/sharedReview/src/main/java/com/sreview/sharedReview/domain/controller/BoardController.java
+++ b/sharedReview/src/main/java/com/sreview/sharedReview/domain/controller/BoardController.java
@@ -125,6 +125,7 @@ public class BoardController {
     public ResponseEntity<? super BoardWriteResponse> boardWrite(
             @RequestBody BoardWriteRequest request,
             @AuthenticationPrincipal String email) {
+        System.out.println("받아온 데이터 => 1. request : " + request + " 2. email : " + email);
         log.info("request = {}", request);
         return boardServcice.saveBoard(request, email);
     }


### PR DESCRIPTION
게시물 본문을 백에서 마크다운 형식으로 변환해서 db에 저장해주고 있음.
하지만 BoardDetail에서는 마크다운 형식의 데이터를 그대로 불러오기 때문에 이미지가 보여지지 않고 마크다운 형식의 텍스트로 보여줌.

클라이언트에서 게시물 본문의 데이터(마크다운)를 받아서 html형식으로 변환해서 랜더링 시켜주기.